### PR TITLE
librosa 0.11.0

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: librosa

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,16 +34,15 @@ requirements:
     - typing_extensions >=4.1.1
     - lazy_loader >=0.1
     - msgpack-python >=1.0
+    # matplotlib powers librosa.display; optional upstream ("display" extra) but kept
+    # in run so the commonly-used librosa.display module works on install (matches conda-forge).
+    - matplotlib-base >=3.5.0
     - standard-aifc  # [py>=313]
     - standard-sunau  # [py>=313]
-  run_constrained:
-    # matplotlib powers librosa.display; optional upstream (the "display" extra).
-    - matplotlib-base >=3.5.0
 
 test:
   requires:
     - pip
-    - matplotlib-base >=3.5.0
   imports:
     - librosa
     - librosa.core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
-{% set version = "0.9.2" %}
-{% set hash_val = "e389bd21c2dc3922d232b13c55e9b965" %}
+{% set version = "0.11.0" %}
 
 package:
   name: librosa
@@ -7,48 +6,64 @@ package:
 
 source:
   fn: librosa-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/l/librosa/librosa-{{ version }}.tar.gz
-  md5: {{ hash_val }}
+  url: https://pypi.org/packages/source/l/librosa/librosa-{{ version }}.tar.gz
+  sha256: f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6
     - setuptools >=48
     - wheel >=0.29.0
-
   run:
-    - python >=3.6
+    - python
     - audioread >=2.1.9
-    - numpy >=1.17.0
-    - scipy >=1.2.0
-    - scikit-learn >=0.19.1
-    - joblib >=0.14.0
-    - matplotlib-base >=3.3.0
-    - decorator >=4.0.10
-    - resampy >=0.2.2
-    - numba >=0.45.1
-    - pysoundfile >=0.10.2
-    - pooch >=1.0
-    - packaging >=20.0
+    - numba >=0.51.0
+    - numpy >=1.22.3
+    - scipy >=1.6.0
+    - scikit-learn >=1.1.0
+    - joblib >=1.0
+    - decorator >=4.3.0
+    - pysoundfile >=0.12.1
+    - pooch >=1.1
+    - soxr-python >=0.3.2
+    - typing_extensions >=4.1.1
+    - lazy_loader >=0.1
+    - msgpack-python >=1.0
+    - standard-aifc  # [py>=313]
+    - standard-sunau  # [py>=313]
+  run_constrained:
+    # matplotlib powers librosa.display; optional upstream (the "display" extra).
+    - matplotlib-base >=3.5.0
 
 test:
+  requires:
+    - pip
+    - matplotlib-base >=3.5.0
   imports:
     - librosa
     - librosa.core
     - librosa.feature
     - librosa.util
     - librosa.display
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/librosa/librosa
+  home: https://github.com/librosa/librosa
   license: ISC
+  license_family: Other
+  license_file: LICENSE.md
   summary: Python module for audio and music processing
+  description: |
+    librosa is a python package for music and audio analysis. It provides the
+    building blocks necessary to create music information retrieval systems.
+  doc_url: https://librosa.org/doc/latest/index.html
+  dev_url: https://github.com/librosa/librosa
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
librosa 0.11.0

**Destination channel:** defaults

### Links

- [PKG-14884](https://anaconda.atlassian.net/browse/PKG-14884)
- [Upstream repository](https://github.com/librosa/librosa)
- [PyPI](https://pypi.org/project/librosa/0.11.0/)

### Explanation of changes:

- Updated librosa from 0.9.2 to 0.11.0 (new package for defaults).


[PKG-14884]: https://anaconda.atlassian.net/browse/PKG-14884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ